### PR TITLE
Adds two missing Create recipes

### DIFF
--- a/src/main/resources/data/scguns/recipes/create/deploying/copper_disc.json
+++ b/src/main/resources/data/scguns/recipes/create/deploying/copper_disc.json
@@ -1,0 +1,17 @@
+{
+  "type": "create:deploying",
+  "ingredients": [
+    {
+      "item": "minecraft:copper_block"
+    },
+    {
+      "item": "scguns:disc_mold"
+    }
+  ],
+  "results": [
+    {
+      "item": "scguns:copper_disc",
+      "count": 2
+    }
+  ]
+}

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/heavy_gun_parts_treated_iron.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/heavy_gun_parts_treated_iron.json
@@ -1,0 +1,70 @@
+{
+  "type": "create:sequenced_assembly",
+  "ingredient": {
+    "item": "scguns:treated_iron_block"
+  },
+  "loops": 1,
+  "results": [
+    {
+      "item": "scguns:heavy_gun_parts"
+    }
+  ],
+  "sequence": [
+    {
+      "type": "create:cutting",
+      "ingredients": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ],
+      "processingTime": 50,
+      "results": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ]
+    },
+    {
+      "type": "create:pressing",
+      "ingredients": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ],
+      "results": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ]
+    },
+    {
+      "type": "create:pressing",
+      "ingredients": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ],
+      "results": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ]
+    },
+    {
+      "type": "create:pressing",
+      "ingredients": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ],
+      "results": [
+        {
+          "item": "scguns:unfinished_heavy_gun_parts"
+        }
+      ]
+    }
+  ],
+  "transitionalItem": {
+    "item": "scguns:unfinished_heavy_gun_parts"
+  }
+}


### PR DESCRIPTION
One is for making 2x copper disc with a disc mold. Another is for making 1x heavy gun parts out of a treated iron block.

I verified that the two recipes for heavy gun parts do not interfere with each other.