### PR TITLE
Fixes ingredient order in Create recipes for assembling shells

### DIFF
--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/bearpack_shell.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/bearpack_shell.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "item": "minecraft:paper"
+    "item": "scguns:medium_brass_casing"
   },
   "loops": 1,
   "results": [
@@ -18,7 +18,7 @@
         },
         [
           {
-            "item": "scguns:medium_brass_casing"
+            "item": "minecraft:paper"
           }
         ]
       ],

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/energy_cell.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/energy_cell.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "item": "scguns:plasma_nugget"
+    "item": "scguns:empty_cell"
   },
   "loops": 1,
   "results": [
@@ -18,7 +18,7 @@
         },
         [
           {
-            "item": "scguns:empty_cell"
+            "item": "scguns:plasma_nugget"
           }
         ]
       ],

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/energy_core.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/energy_core.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "item": "minecraft:redstone_block"
+    "item": "scguns:empty_core"
   },
   "loops": 1,
   "results": [
@@ -18,7 +18,7 @@
         },
         [
           {
-            "item": "scguns:empty_core"
+            "item": "minecraft:redstone_block"
           }
         ]
       ],

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/hog_round.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/hog_round.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "item": "minecraft:gold_nugget"
+    "item": "scguns:small_iron_casing"
   },
   "loops": 1,
   "results": [
@@ -36,7 +36,7 @@
         },
         [
           {
-            "item": "scguns:small_iron_casing"
+            "item": "minecraft:gold_nugget"
           }
         ]
       ],

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/microjet.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/microjet.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "tag": "scguns:stan_bullet_tips"
+    "item": "scguns:small_iron_casing"
   },
   "loops": 1,
   "results": [
@@ -18,7 +18,7 @@
         },
         [
           {
-            "tag": "forge:gunpowder"
+            "item": "minecraft:gunpowder"
           }
         ]
       ],
@@ -36,7 +36,7 @@
         },
         [
           {
-            "item": "scguns:small_iron_casing"
+            "tag": "scguns:stan_bullet_tips"
           }
         ]
       ],

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/rocket.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/rocket.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "item": "scguns:sheol"
+    "item": "scguns:large_iron_casing"
   },
   "loops": 1,
   "results": [
@@ -18,7 +18,7 @@
         },
         [
           {
-            "item": "scguns:large_iron_casing"
+            "item": "scguns:sheol"
           }
         ]
       ],

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/sculk_cell.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/sculk_cell.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "item": "scguns:peal"
+    "item": "scguns:empty_cell"
   },
   "loops": 1,
   "results": [
@@ -18,7 +18,7 @@
         },
         [
           {
-            "item": "scguns:empty_cell"
+            "item": "scguns:peal"
           }
         ]
       ],

--- a/src/main/resources/data/scguns/recipes/create/sequenced_assembly/shotgun_shell.json
+++ b/src/main/resources/data/scguns/recipes/create/sequenced_assembly/shotgun_shell.json
@@ -1,7 +1,7 @@
 {
   "type": "create:sequenced_assembly",
   "ingredient": {
-    "item": "minecraft:paper"
+    "item": "scguns:small_copper_casing"
   },
   "loops": 1,
   "results": [
@@ -18,7 +18,7 @@
         },
         [
           {
-            "item": "scguns:small_copper_casing"
+            "item": "minecraft:paper"
           }
         ]
       ],


### PR DESCRIPTION
All shell recipes now start with an empty shell, instead of that semi-random order.

I verified that the changed recipes do not interfere with each other.