### PR TITLE
Fire Projectile Purifies w/Sculk Horde

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     compileOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-common-api:${jei_version}"))
     compileOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-forge-api:${jei_version}"))
     runtimeOnly(fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}"))
-    implementation fg.deobf("curse.maven:geckolib-388172:5675221")
+    implementation fg.deobf("curse.maven:geckolib-388172:7020955")
     implementation fg.deobf("curse.maven:create-328085:5689514")
     //implementation fg.deobf("curse.maven:createaddition-439890:5658602")
     implementation fg.deobf("curse.maven:shoulder-surfing-reloaded-243190:5455954")
@@ -130,6 +130,7 @@ dependencies {
     implementation fg.deobf("curse.maven:effortless-building-302113:5805519")
     implementation fg.deobf("curse.maven:create-enchantment-industry-688768:5331908")
     implementation fg.deobf("curse.maven:born-in-chaos-686437:6833957")
+    implementation fg.deobf("curse.maven:sculk-horde-501766:7001682")
 }
 
 jar {

--- a/src/main/java/top/ribs/scguns/ScorchedGuns.java
+++ b/src/main/java/top/ribs/scguns/ScorchedGuns.java
@@ -30,6 +30,7 @@ import top.ribs.scguns.common.exosuit.ExoSuitUpgradeManager;
 import top.ribs.scguns.compat.CreateModCondition;
 import top.ribs.scguns.compat.FarmersDelightModCondition;
 import top.ribs.scguns.compat.IEModCondition;
+import top.ribs.scguns.event.SculkHordeEvents;
 import top.ribs.scguns.config.MerchantTradeConfig;
 import top.ribs.scguns.config.ProjectileAdvantageConfig;
 import top.ribs.scguns.entity.config.ConfigLoader;
@@ -46,6 +47,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import static top.ribs.scguns.Reference.MOD_ID;
+import static top.ribs.scguns.compat.CompatManager.SCULK_HORDE_LOADED;
 
 @Mod(MOD_ID)
 public class ScorchedGuns {
@@ -122,6 +124,11 @@ public class ScorchedGuns {
         MinecraftForge.EVENT_BUS.register(PiglinWeaponEventHandler.class);
         MinecraftForge.EVENT_BUS.register(MerchantTradeConfig.class);
         MinecraftForge.EVENT_BUS.register(ProjectileAdvantageConfig.class);
+
+
+        if (SCULK_HORDE_LOADED) {
+            MinecraftForge.EVENT_BUS.register(SculkHordeEvents.class);
+        }
     }
     private void onConfigLoad(ModConfigEvent.Loading event) {
         if (event.getConfig().getType() == ModConfig.Type.SERVER) {

--- a/src/main/java/top/ribs/scguns/compat/CompatManager.java
+++ b/src/main/java/top/ribs/scguns/compat/CompatManager.java
@@ -1,0 +1,17 @@
+package top.ribs.scguns.compat;
+
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.loading.FMLLoader;
+import net.minecraftforge.fml.loading.moddiscovery.ModFileInfo;
+
+public class CompatManager {
+    public static final boolean SCULK_HORDE_LOADED = modLoaded("sculkhorde");
+
+
+    public static boolean modLoaded(String modID) {
+        ModFileInfo mod = FMLLoader.getLoadingModList().getModFileById(modID);
+        return mod != null;
+    }
+
+
+}

--- a/src/main/java/top/ribs/scguns/event/SculkHordeEvents.java
+++ b/src/main/java/top/ribs/scguns/event/SculkHordeEvents.java
@@ -1,0 +1,75 @@
+package top.ribs.scguns.event;
+
+
+import com.github.sculkhorde.common.entity.infection.CursorSurfacePurifierEntity;
+import com.github.sculkhorde.core.ModMobEffects;
+import com.github.sculkhorde.systems.infestation_systems.block_infestation_system.BlockInfestationSystem;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import top.ribs.scguns.entity.projectile.FireRoundEntity;
+import top.ribs.scguns.entity.projectile.ProjectileEntity;
+
+public class SculkHordeEvents {
+    //Doing this in a separate event, so we can do this optionally.
+    @SubscribeEvent
+    public static void onProjectileHit(GunProjectileHitEvent event) {
+        if (event.getProjectile().level().isClientSide) {
+            return;
+        }
+
+        ProjectileEntity projectile = event.getProjectile();
+        if (!(projectile instanceof FireRoundEntity)) return;
+
+        Level level = projectile.level();
+        HitResult result = event.getRayTrace();
+
+
+        if (result.getType() == HitResult.Type.BLOCK) {
+            BlockHitResult blockResult = (BlockHitResult) result;
+
+            SpawnCursorAndDisinfect(1, blockResult.getBlockPos(), level);
+        }
+
+        if (result.getType() == HitResult.Type.ENTITY) {
+            EntityHitResult entResult = (EntityHitResult) result;
+            Entity entity = entResult.getEntity();
+
+            if (entity instanceof LivingEntity livingEntity) {
+                livingEntity.addEffect(new MobEffectInstance(ModMobEffects.PURITY.get(), 20*10));
+            }
+
+            SpawnCursorAndDisinfect(1, entity.blockPosition(), level);
+        }
+    }
+
+    private static void SpawnCursorAndDisinfect(int size, BlockPos pos, Level level) {
+        for (int y = -size; y < size; y++) {
+            for (int x = -size; x < size; x++) {
+                for (int z = -size; z < size; z++) {
+                    BlockPos new_pos = new BlockPos(pos.getX() + x, pos.getY() + y, pos.getZ() + z);
+                    BlockInfestationSystem.tryToCureBlock((ServerLevel) level, new_pos);
+                }
+            }
+        }
+
+        if (Math.random() >= 0.33) {
+            CursorSurfacePurifierEntity cursorEntity = new CursorSurfacePurifierEntity(level);
+
+            cursorEntity.setPos(pos.getCenter());
+            cursorEntity.setMaxTransformations(8);
+            cursorEntity.setMaxRange(50);
+            cursorEntity.setSearchIterationsPerTick(5);
+            cursorEntity.setMaxLifeTimeMillis(10000 / 2);
+            cursorEntity.setTickIntervalMilliseconds(150);
+            level.addFreshEntity(cursorEntity);
+        }
+    }
+}


### PR DESCRIPTION
Fire Projectiles now purify sculk instead of breaking it with Sculk Horde installed.

Also updated geckolib version as sculk horde needed it.