### PR TITLE
JEI Transfer support for the Gunbench.

### DIFF
--- a/src/main/java/top/ribs/scguns/client/screen/GunBenchMenu.java
+++ b/src/main/java/top/ribs/scguns/client/screen/GunBenchMenu.java
@@ -62,19 +62,6 @@ public class GunBenchMenu extends AbstractContainerMenu {
         this.addSlot(new Slot(container, SLOT_BARREL_2, 80, 35));
         this.addSlot(new Slot(container, SLOT_GRIP, 26, 53));
         this.addSlot(new Slot(container, SLOT_MAGAZINE, 62, 53));
-        this.addSlot(new Slot(container, SLOT_BLUEPRINT, 116, 17) {
-            @Override
-            public boolean mayPlace(@NotNull ItemStack stack) {
-                return stack.getItem() instanceof BlueprintItem;
-            }
-
-            @Override
-            public void setChanged() {
-                super.setChanged();
-                // When blueprint slot changes, attempt auto-crafting
-                attemptAutoCrafting();
-            }
-        });
         this.addSlot(new Slot(container, SLOT_OUTPUT, 140, 44) {
             @Override
             public boolean mayPlace(ItemStack stack) {
@@ -85,6 +72,18 @@ public class GunBenchMenu extends AbstractContainerMenu {
             public void onTake(Player player, ItemStack stack) {
                 super.onTake(player, stack);
                 consumeIngredients();
+            }
+        });
+        this.addSlot(new Slot(container, SLOT_BLUEPRINT, 116, 17) { // the ordering MATTER AHHHH
+            @Override
+            public boolean mayPlace(@NotNull ItemStack stack) {
+                return stack.getItem() instanceof BlueprintItem;
+            }
+
+            @Override
+            public void setChanged() {
+                super.setChanged();
+                attemptAutoCrafting();
             }
         });
 

--- a/src/main/java/top/ribs/scguns/compat/GunBenchTransferInfo.java
+++ b/src/main/java/top/ribs/scguns/compat/GunBenchTransferInfo.java
@@ -1,0 +1,65 @@
+package top.ribs.scguns.compat;
+
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.crafting.Ingredient;
+import top.ribs.scguns.client.screen.GunBenchMenu;
+import top.ribs.scguns.client.screen.GunBenchRecipe;
+import top.ribs.scguns.client.screen.ModMenuTypes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class GunBenchTransferInfo implements IRecipeTransferInfo<GunBenchMenu, GunBenchRecipe> {
+
+    @Override
+    public Class<GunBenchMenu> getContainerClass() {
+        return GunBenchMenu.class;
+    }
+
+    @Override
+    public Optional<MenuType<GunBenchMenu>> getMenuType() {
+        return Optional.of(ModMenuTypes.GUN_BENCH.get());
+    }
+
+    @Override
+    public RecipeType<GunBenchRecipe> getRecipeType() {
+        return GunBenchCategory.GUN_BENCH_TYPE;
+    }
+
+    @Override
+    public boolean canHandle(GunBenchMenu container, GunBenchRecipe recipe) {
+        return true;
+    }
+
+    @Override
+    public List<Slot> getRecipeSlots(GunBenchMenu container, GunBenchRecipe recipe) {
+        List<Slot> slots = new ArrayList<>();
+        NonNullList<Ingredient> ingredients = recipe.getIngredients();
+
+        for (int i = 0; i < ingredients.size(); i++) {
+            if (!ingredients.get(i).isEmpty()) {
+                slots.add(container.getSlot(i));
+            }
+        }
+
+        if (!recipe.getBlueprint().isEmpty()) {
+            slots.add(container.getSlot(GunBenchMenu.SLOT_BLUEPRINT));
+        }
+
+        return slots;
+    }
+
+    @Override
+    public List<Slot> getInventorySlots(GunBenchMenu container, GunBenchRecipe recipe) {
+        List<Slot> slots = new ArrayList<>();
+        for (int i = 12; i < container.slots.size(); i++) {
+            slots.add(container.getSlot(i));
+        }
+        return slots;
+    }
+}

--- a/src/main/java/top/ribs/scguns/compat/JEIScorchedPlugin.java
+++ b/src/main/java/top/ribs/scguns/compat/JEIScorchedPlugin.java
@@ -4,7 +4,6 @@ import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.constants.VanillaTypes;
 import mezz.jei.api.helpers.IGuiHelper;
-import mezz.jei.api.recipe.RecipeType;
 import mezz.jei.api.registration.*;
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.client.Minecraft;
@@ -113,8 +112,6 @@ public class JEIScorchedPlugin implements IModPlugin {
         registration.addRecipes(MechanicalPressCategory.MECHANICAL_PRESS_TYPE, mechanicalPressRecipes);
         registration.addRecipes(PoweredMechanicalPressCategory.POWERED_MECHANICAL_PRESS_TYPE, poweredMechanicalPressRecipes);
         registration.addRecipes(LightningBatteryCategory.LIGHTNING_BATTERY_TYPE, recipeManager.getAllRecipesFor(LightningBatteryRecipe.Type.INSTANCE));
-
-
     }
 
     @Override
@@ -135,6 +132,11 @@ public class JEIScorchedPlugin implements IModPlugin {
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.MECHANICAL_PRESS.get()), MechanicalPressCategory.MECHANICAL_PRESS_TYPE);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.POWERED_MECHANICAL_PRESS.get()), PoweredMechanicalPressCategory.POWERED_MECHANICAL_PRESS_TYPE);
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.LIGHTNING_BATTERY.get()), LightningBatteryCategory.LIGHTNING_BATTERY_TYPE);
+    }
+
+    @Override
+    public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
+        registration.addRecipeTransferHandler(new GunBenchTransferInfo());
     }
 }
 


### PR DESCRIPTION
Support to add JEI transferring to the gunbench. 

I think it's something that was sorely missed from the mod (even though it's a JEI thing), as I personally didn't care for hand crafting as well as knowing if I had the right items in my inventory.

I had to adjust GunBenchMenu to swap how it registers slots, but that ordering shouldn't matter for anything else, I hope. Instead of having the output, then the blueprint, it's the blueprint, then the output. There was a weird issue where the blueprint didn't get moved into the menu because of it and so thats why I touched that.

Testing-wise, this is the second time I have made a feature like this, so it might not be up to par and may have some bugs, but from what I have seen when looking at other implementations, it seems fine as long as you don't have some really funky recipe that breaks the rules of having blueprint items as blueprintitem objects.

Here is a video of how it works, so you know what this feature does explicitly.
https://github.com/user-attachments/assets/fb907315-22ab-430d-bfa0-93e7ac332369

