### PR TITLE
Random World Crash Fix

### DIFF
--- a/src/main/java/top/ribs/scguns/entity/raid/RaidManager.java
+++ b/src/main/java/top/ribs/scguns/entity/raid/RaidManager.java
@@ -175,7 +175,6 @@ public class RaidManager {
 
         if (level.getGameTime() % SAVE_INTERVAL == 0) {
             saveActiveRaids(level);
-            level.getDataStorage().save();
         }
     }
 


### PR DESCRIPTION
Removed unnecessary (?) level save as it is already marked dirty previously, causing random crashes on raid events.

This should fix #110 

The current version of the mod is based on master2, which is the only place I could find the raid folder with this issue, as main master doesn't have this.